### PR TITLE
Fix/archive submit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,10 @@
 .venv/
 .env
+__pycache__/
+*.pyc
 
 atcoder/*
-!atcoder/
 codeforces/*
-!codeforces/
 
 luogu/*
 !luogu/

--- a/README.md
+++ b/README.md
@@ -59,15 +59,17 @@ pip install -r requirements.txt
    ```ini
    # .env 示例
    VJUDGE_COOKIE=your_vjudge_cookie_here
-   
+
    CF_USER=your_CodeForces_username_here
    ATC_USER=your_AtCoder_username_here
    ```
 
-> 在 [VJudge.net](https://vjudge.net/problem) 中按 F12 打开开发者工具（DevTools），在控制台（Console）中输入下面的代码即可获取所需的 cookie
-> ```js
-> prompt("复制以下 Cookie:", document.cookie);
-> ```
+> 获取 Cookie 的方法：
+>
+> 1. 打开 [VJudge.net](https://vjudge.net) 并登录
+> 2. 按 F12 打开开发者工具，切换到 **Network（网络）** 面板
+> 3. 按 F5 刷新页面，点击列表中第一个请求
+> 4. 在右侧 **Request Headers** 中找到 `Cookie` 字段，复制其完整值
 
 ### 6. 配置
 
@@ -77,8 +79,8 @@ pip install -r requirements.txt
 - [CodeForces-1A](https://vjudge.net/problem/CodeForces-1A)
 - [洛谷-P1001](https://vjudge.net/problem/洛谷-P1001)
 
-> 依次点击 `Submit`、`Submit by: Archive`、`Update`，填入对应的值。
-> 参考 [Submit with your own account](https://vjudge.net/article/2790)。
+> 依次点击 `Submit（提交）`、`Submit by: Archive（归档）`、`Manage Accounts（管理账号）`，绑定远程账号。
+> 可参考 [Submit with your own account](https://vjudge.net/article/2790)。
 
 ### 7. 获取洛谷题目数据
 
@@ -96,19 +98,22 @@ pip install -r requirements.txt
 python main.py
 ```
 
-## 注意：解决状态码 401 错误的方法
+## 故障排除
 
-在使用过程中，如果遇到类似 `❗ 发送 xxx 的更新请求失败, 状态码：401` 的错误，请依照以下步骤逐步排查并解决问题：
+### Cookie 失效（login_required）
 
-1. 获取最新 Cookie：
-   - 打开 [VJudge.net](https://vjudge.net) 并重新登录账号。
-   - 参照上面的配置环境变量步骤重新配置 VJUDGE_COOKIE
+如果遇到 `⚠️ 更新 xxx 时 Cookie 已失效` 的警告，脚本会自动重新加载 `.env` 中的 Cookie 并重试一次。如果仍然失败，请手动更新 Cookie：
 
-2. 获取完整 Cookie：
-   - 如果更新后问题依旧，按 F12 打开开发者工具并切换到 **Network（网络）** 面板。
-   - 按 F5 刷新页面，点击任意一个网络请求（如 `.png` 的请求）
-   - 查看请求头中的 Cookie 信息，将其完整复制到 `.env` 文件更新对应的 `VJUDGE_COOKIE` 变量。
+1. 打开 [VJudge.net](https://vjudge.net) 并重新登录
+2. 按 F12 → Network → 刷新页面 → 点击第一个请求 → 复制 Request Headers 中的 `Cookie` 值
+3. 更新 `.env` 中的 `VJUDGE_COOKIE`
 
+### 远程 OJ 账号无效（own_account.error.invalid）
+
+如果提交返回 `远程 OJ 账号无效或未绑定`，请在 VJudge 中重新绑定远程 OJ 账号：
+
+- 打开对应题目的提交对话框，点击"管理账号"链接
+- 参考 [Submit with your own account](https://vjudge.net/article/2790)
 
 ## 贡献
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # VJudge 获取 OJ 提交脚本
 
-该项目是一个用 Python 编写的脚本，用于从 VJudge 批量获取账号在 OJ 的提交数据。项目使用虚拟环境 (venv) 管理依赖，并通过 .env 文件配置环境变量。
+该项目是一个用 Python 编写的脚本，用于从 VJudge 批量获取账号在 OJ 的提交数据。项目使用 [uv](https://docs.astral.sh/uv/) 管理依赖，并通过 `.env` 文件配置环境变量。
 
 ## 已支持 OJ
 
@@ -12,44 +12,20 @@
 
 ### 1. 克隆仓库
 
-使用 Git 克隆项目到本地：
-
 ```bash
 git clone https://github.com/xiaowhang/vjudge-submission-tracker.git
 cd vjudge-submission-tracker
 ```
 
-### 2. 创建虚拟环境
+### 2. 安装依赖
 
-建议使用 Python 内置的 `venv` 模块创建虚拟环境：
-
-```bash
-python3 -m venv .venv
-```
-
-### 3. 激活虚拟环境
-
-- **Windows：**
-
-  ```bash
-  .venv\Scripts\activate
-  ```
-
-- **macOS/Linux：**
-
-  ```bash
-  source .venv/bin/activate
-  ```
-
-### 4. 安装依赖
-
-在虚拟环境激活状态下，使用 `pip` 安装项目依赖：
+使用 [uv](https://docs.astral.sh/uv/) 安装依赖：
 
 ```bash
-pip install -r requirements.txt
+uv sync
 ```
 
-### 5. 配置环境变量
+### 3. 配置环境变量
 
 项目使用 `.env` 文件存储环境变量信息。请按照以下步骤进行配置：
 
@@ -71,9 +47,9 @@ pip install -r requirements.txt
 > 3. 按 F5 刷新页面，点击列表中第一个请求
 > 4. 在右侧 **Request Headers** 中找到 `Cookie` 字段，复制其完整值
 
-### 6. 配置
+### 4. 配置远程账号
 
-在 [VJudge.net](https://vjudge.net/problem) 中给每个平台的题目添加账号信息：
+在 [VJudge.net](https://vjudge.net/problem) 中给每个平台的题目绑定远程账号：
 
 - [AtCoder-abc123_a](https://vjudge.net/problem/AtCoder-abc123_a)
 - [CodeForces-1A](https://vjudge.net/problem/CodeForces-1A)
@@ -82,7 +58,7 @@ pip install -r requirements.txt
 > 依次点击 `Submit（提交）`、`Submit by: Archive（归档）`、`Manage Accounts（管理账号）`，绑定远程账号。
 > 可参考 [Submit with your own account](https://vjudge.net/article/2790)。
 
-### 7. 获取洛谷题目数据
+### 5. 获取洛谷题目数据
 
 因洛谷没有 API 获取帐号提交的详细信息，故需手动添加通过的题号：
 
@@ -90,12 +66,10 @@ pip install -r requirements.txt
 
 在 luogu 文件夹下新建 `problems.txt` 文件，将题目编号直接复制粘贴进去，格式见 `luogu/problems.example.txt` 文件（普及− 等信息可有可无）。
 
-### 8. 运行脚本
-
-在虚拟环境中运行主程序：
+### 6. 运行脚本
 
 ```bash
-python main.py
+uv run main.py
 ```
 
 ## 故障排除

--- a/main.py
+++ b/main.py
@@ -6,7 +6,9 @@ import os
 import dotenv
 import requests
 
-logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
+)
 
 os.chdir(os.path.dirname(os.path.abspath(__file__)))
 
@@ -34,14 +36,19 @@ def write_json(filename, data):
 class Vjudge:
     DEFAULT_DATA = {
         "method": "2",
-        "language": None,  # 语言 ID
+        "language": "",  # 归档模式下为空
         "open": "1",  # 是否公开代码
-        "source": "",
+        "source": "",  # 归档模式下为空
         "oj": None,  # OJ 平台
         "probNum": None,  # 题目编号
     }
 
     SUBMIT_URL = "https://vjudge.net/problem/submit"
+
+    HEADERS = {
+        "x-requested-with": "XMLHttpRequest",
+        "referer": "https://vjudge.net/",
+    }
 
     def __init__(self):
         if not dotenv.find_dotenv():
@@ -49,14 +56,27 @@ class Vjudge:
             return
 
         dotenv.load_dotenv()
-        self.cookies = dict(item.split("=", 1) for item in os.getenv("VJUDGE_COOKIE").split("; "))
+        self.session = requests.Session()
+        self.session.headers.update(self.HEADERS)
+        self._load_cookies()
         self.oj_config = {
-            "atcoder": {"language": "5001", "oj": "AtCoder"},
-            "codeforces": {"language": "91", "oj": "CodeForces"},
-            "luogu": {"language": "27", "oj": "洛谷"},
+            "atcoder": {"oj": "AtCoder"},
+            "codeforces": {"oj": "CodeForces"},
+            "luogu": {"oj": "洛谷"},
         }
 
         self.update_problems()
+
+    def _load_cookies(self):
+        for item in os.getenv("VJUDGE_COOKIE").split("; "):
+            key, value = item.split("=", 1)
+            self.session.cookies.set(key, value, domain="vjudge.net")
+
+    def reload_cookies(self):
+        logging.info("🔄 重新加载 Cookie")
+        dotenv.load_dotenv(override=True)
+        self.session.cookies.clear()
+        self._load_cookies()
 
     def update_problems(self):
         logging.info("开始更新做题信息")
@@ -70,53 +90,119 @@ class Vjudge:
             os.mkdir(oj_name)
         os.chdir(oj_name)
 
-        if oj_name == "atcoder":
-            self.get_ATC_problem()
-        elif oj_name == "codeforces":
-            self.get_CF_problem()
-        elif oj_name == "luogu":
-            self.get_LG_problem()
-
-        logging.info(f"开始提交 {oj_name} 做题信息")
-
-        problems = read_lines("problems.txt")
         try:
-            succ = read_json("success_problems.json")
-        except FileNotFoundError:
-            succ = {}
+            if oj_name == "atcoder":
+                self.get_ATC_problem()
+            elif oj_name == "codeforces":
+                self.get_CF_problem()
+            elif oj_name == "luogu":
+                self.get_LG_problem()
 
-        for problem in problems:
-            if problem in succ and "success" in succ[problem] and succ[problem]["success"]:
-                continue
+            logging.info(f"开始提交 {oj_name} 做题信息")
 
-            if problem in succ and "error" in succ[problem] and succ[problem]["error"] == "No recent submissions found":
-                continue
+            problems = read_lines("problems.txt")
+            try:
+                succ = read_json("success_problems.json")
+            except FileNotFoundError:
+                succ = {}
 
-            data = copy.deepcopy(self.DEFAULT_DATA)
-            for key, value in self.oj_config[oj_name].items():
-                data[key] = value
-            data["probNum"] = problem
+            def _get_i18n_key(result):
+                error = result.get("error")
+                if isinstance(error, dict):
+                    return error.get("i18nKey", "")
+                return ""
 
-            if oj_name == "codeforces" and len(problem) > 6:
-                data["oj"] = "Gym"
+            for problem in problems:
+                if (
+                    problem in succ
+                    and "success" in succ[problem]
+                    and succ[problem]["success"]
+                ):
+                    continue
 
-            response = requests.post(f"{self.SUBMIT_URL}/{data['oj']}-{data['probNum']}", data=data, cookies=self.cookies)
+                i18n_key = _get_i18n_key(succ.get(problem, {}))
 
-            if response.status_code != 200:
-                logging.error(f"❗ 发送 {data['oj']}-{data['probNum']} 的更新请求失败, 状态码：{response.status_code}")
-                if response.status_code == 401:
-                    logging.error("❗ 请检查 VJUDGE_COOKIE 是否已过期或从网络请求中获取完整的 Cookie（参考 README.md）")
-                continue
+                if i18n_key.endswith("no_recent_submissions_found"):
+                    continue
 
-            succ[problem] = json.loads(response.text)
-            write_json("success_problems.json", succ)
+                data = copy.deepcopy(self.DEFAULT_DATA)
+                for key, value in self.oj_config[oj_name].items():
+                    data[key] = value
+                data["probNum"] = problem
 
-            if succ[problem].get("success") or succ[problem].get("error") == "No recent submissions found":
-                logging.info(f"✅ 更新 {data['oj']}-{data['probNum']} 成功")
-            else:
-                logging.warning(f"❌ 更新 {data['oj']}-{data['probNum']} 失败，错误信息：{succ[problem]['error']}")
+                if oj_name == "codeforces" and len(problem) > 6:
+                    data["oj"] = "Gym"
 
-        os.chdir("..")
+                response = self.session.post(
+                    f"{self.SUBMIT_URL}/{data['oj']}-{data['probNum']}",
+                    data=data,
+                )
+
+                if response.status_code != 200:
+                    logging.error(
+                        f"❗ 发送 {data['oj']}-{data['probNum']} 的更新请求失败, 状态码：{response.status_code}"
+                    )
+                    if response.status_code == 401:
+                        logging.error(
+                            "❗ 请检查 VJUDGE_COOKIE 是否已过期或从网络请求中获取完整的 Cookie（参考 README.md）"
+                        )
+                    continue
+
+                result = json.loads(response.text)
+
+                # 检测登录失效，重新加载 Cookie 并重试一次
+                if _get_i18n_key(result).endswith("login_required"):
+                    logging.warning(
+                        f"⚠️ 更新 {data['oj']}-{data['probNum']} 时 Cookie 已失效，尝试重新加载"
+                    )
+                    self.reload_cookies()
+                    response = self.session.post(
+                        f"{self.SUBMIT_URL}/{data['oj']}-{data['probNum']}",
+                        data=data,
+                    )
+                    if response.status_code == 200:
+                        result = json.loads(response.text)
+                    else:
+                        logging.error(
+                            f"❗ 重试 {data['oj']}-{data['probNum']} 失败，状态码：{response.status_code}"
+                        )
+                        continue
+
+                    # 重试后仍然登录失败，终止当前 OJ 的提交
+                    if _get_i18n_key(result).endswith("login_required"):
+                        logging.error(
+                            "❗ 重试后仍然登录失败，请手动更新 VJUDGE_COOKIE（参考 README.md）"
+                        )
+                        break
+
+                succ[problem] = result
+                write_json("success_problems.json", succ)
+
+                i18n_key = _get_i18n_key(result)
+                if result.get("success") or i18n_key.endswith(
+                    "no_recent_submissions_found"
+                ):
+                    logging.info(f"✅ 更新 {data['oj']}-{data['probNum']} 成功")
+                else:
+                    i18n_map = {
+                        "no_recent_submissions_found": "没有找到最近提交",
+                        "login_required": "Cookie 已失效，请更新 VJUDGE_COOKIE",
+                        "invalid": "远程 OJ 账号无效或未绑定",
+                    }
+                    error_msg = (
+                        i18n_key.split(".")[-1] if i18n_key else result.get("error")
+                    )
+                    if isinstance(error_msg, dict):
+                        error_msg = error_msg.get("i18nKey", str(error_msg))
+                    error_msg = i18n_map.get(error_msg, str(error_msg))
+                    logging.warning(
+                        f"❌ 更新 {data['oj']}-{data['probNum']} 失败，错误信息：{error_msg}"
+                    )
+                    # 账号无效时终止当前 OJ 的提交（后续题目也会失败）
+                    if i18n_key.endswith("own_account.error.invalid"):
+                        break
+        finally:
+            os.chdir("..")
 
     def get_ATC_problem(self):
         logging.info(f"获取 {'AtCoder':^10} 题目信息")
@@ -185,7 +271,16 @@ class Vjudge:
         except FileNotFoundError:
             problems = []
 
-        for item in ["暂无评定", "入门", "普及−", "普及/提高−", "普及+/提高", "提高+/省选−", "省选/NOI−", "NOI/NOI+/CTSC"]:
+        for item in [
+            "暂无评定",
+            "入门",
+            "普及−",
+            "普及/提高−",
+            "普及+/提高",
+            "提高+/省选−",
+            "省选/NOI−",
+            "NOI/NOI+/CTSC",
+        ]:
             if item in problems:
                 problems.remove(item)  # 删除无效信息
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,9 @@
+[project]
+name = "vjudge-submission-tracker"
+version = "1.0.0"
+description = "从 VJudge 批量获取账号在 OJ 的提交数据"
+requires-python = ">=3.10"
+dependencies = [
+    "requests>=2.32",
+    "python-dotenv>=1.0",
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,0 @@
-certifi==2025.1.31
-charset-normalizer==3.4.1
-dotenv==0.9.9
-idna==3.10
-python-dotenv==1.0.1
-requests==2.32.3
-urllib3==2.3.0


### PR DESCRIPTION
## Summary

  - 修正提交参数匹配 VJudge 归档提交协议（method=2, language, source, open）
  - 修复 i18n 错误码解析（检查 `error.i18nKey` 而非顶层 `i18nKey`）
  - 添加 `login_required` 自动重试机制
  - 添加中文错误信息映射
  - 用 `requests.Session` 替代手动 Cookie 管理
  - 用 `try/finally` 确保 `os.chdir` 异常安全
  - 迁移至 uv 管理依赖

  Closes #2